### PR TITLE
Added a `tap` module to create positives for internal threads

### DIFF
--- a/tests/taptest.scad
+++ b/tests/taptest.scad
@@ -1,0 +1,12 @@
+use <threadlib/threadlib.scad>;
+
+intersection() {
+    union() {
+        difference() {
+            cylinder(r = 15, h = 20);
+            tap("G1/2", 8);
+        }
+        bolt("G1/2", 8);
+    }
+    cube([20, 20, 20]);
+}

--- a/threadlib.scad
+++ b/threadlib.scad
@@ -62,3 +62,17 @@ module nut(designator, turns, Douter, higbee_arc=20, fn=120, table=THREAD_TABLE)
             };
     };
 };
+
+module tap(designator, turns, higbee_arc=20, fn=120, table=THREAD_TABLE) {
+    difference() {
+        specs = thread_specs(str(designator, "-int"), table=table);
+        P = specs[0]; Dsupport = specs[2];
+        H = (turns + 1) * P;        
+
+        translate([0, 0, -P / 2]) {
+            cylinder(h=H, d=Dsupport, $fn=fn);
+        };
+        
+        thread(str(designator, "-int"), turns=turns, higbee_arc=higbee_arc, fn=fn, table=table);
+    };
+}


### PR DESCRIPTION
While switching some existing projects over to use this library (which I consider to produce better thread geometry much faster than other libs I've used) I ran across the mental block of adding interior threads to a pre-cut hollow, which broke my brain a bit.

I find it more natural to think of adding a threaded hole to a solid as a 'tap' or difference() operation, rather than differencing a hollow and then adding interior threads to it.

For this reason I've created the, `tap(...)` module, which creates a positive of the internal threads suitable for differencing to produce a threaded tap hole.

A simple test-case demonstrating the cross-section of a tap() and a bolt() is included.