### PR TITLE
Added nut_sides parameter to allow creation of non-cylinder nut

### DIFF
--- a/docs/README.rst
+++ b/docs/README.rst
@@ -97,7 +97,11 @@ argument for higbee_arc):
         :alt: M12x0.5 nut
 
 Note that for a nut you also have to specify an outer diameter. The inner
-diameter is implicitly given by the thread designator ("M12x0.5" in this case).
+diameter is implicitly given by the thread designator ("M12x0.5" in this case). You can set the number of sides for the nut! So you can make hex nuts:
+
+.. code-block:: OpenScad
+
+        nut("M30", turns=4, Douter=46, nut_sides=6); 
 
 To make a threaded hole (e.g. in a plate), an intuitive approach would be to
 create the difference of the plate and a bolt. However, this part would not work

--- a/docs/img_prep/nut_sides.scad
+++ b/docs/img_prep/nut_sides.scad
@@ -1,0 +1,15 @@
+/*
+Demo nut_sides argument of nut() module.
+*/
+
+use <threadlib/threadlib.scad>
+include <../../THREAD_TABLE.scad>
+
+type = "M12x0.5";
+turns = 7;
+Douter = 16;
+higbee_arc = 45;
+fn = 16;
+nut_sides = 6;
+
+nut(type, turns, Douter, higbee_arc, fn, THREAD_TABLE, nut_sides);

--- a/threadlib.scad
+++ b/threadlib.scad
@@ -48,7 +48,8 @@ module bolt(designator, turns, higbee_arc=20, fn=120, table=THREAD_TABLE) {
     };
 };
 
-module nut(designator, turns, Douter, higbee_arc=20, fn=120, table=THREAD_TABLE) {
+module nut(designator, turns, Douter, higbee_arc=20, fn=120, nut_sides=120, table=THREAD_TABLE) {
+    nut_sides = nut_sides == 120 ? fn : nut_sides;
     union() {
         specs = thread_specs(str(designator, "-int"), table=table);
         P = specs[0]; Dsupport = specs[2];
@@ -57,7 +58,7 @@ module nut(designator, turns, Douter, higbee_arc=20, fn=120, table=THREAD_TABLE)
 
         translate([0, 0, -P / 2])
             difference() {
-                cylinder(h=H, d=Douter, $fn=fn);
+                cylinder(h=H, d=Douter, $fn=nut_sides);
                 translate([0, 0, -0.1])
                     cylinder(h=H+0.2, d=Dsupport, $fn=fn);
             };

--- a/threadlib.scad
+++ b/threadlib.scad
@@ -48,8 +48,8 @@ module bolt(designator, turns, higbee_arc=20, fn=120, table=THREAD_TABLE) {
     };
 };
 
-module nut(designator, turns, Douter, higbee_arc=20, fn=120, nut_sides=120, table=THREAD_TABLE) {
-    nut_sides = nut_sides == 120 ? fn : nut_sides;
+module nut(designator, turns, Douter, higbee_arc=20, fn=120, table=THREAD_TABLE, nut_sides=0) {
+    nut_sides = nut_sides == 0 ? fn : nut_sides;
     union() {
         specs = thread_specs(str(designator, "-int"), table=table);
         P = specs[0]; Dsupport = specs[2];


### PR DESCRIPTION
Added a new parameter to the nut module that allows the creation of non cylinder nuts.
```openscad
nut("M30", turns=3, Douter=46, nut_sides=6);
```
Would yield this: 
![image](https://github.com/adrianschlatter/threadlib/assets/14183081/f99283c2-4135-476a-b47a-e27651d29805)
